### PR TITLE
Feat: MediaLoader

### DIFF
--- a/obj_detectors/obj_detector.py
+++ b/obj_detectors/obj_detector.py
@@ -77,7 +77,12 @@ if __name__ == "__main__":
 
     s = sys.argv[1]
     media_loader = MediaLoader(s)
-    time.sleep(1)
+    media_loader.start()
+
+    while media_loader.is_frame_ready() is False:
+        time.sleep(0.01)
+        continue
+
     f_cnt = 0
     ts = [0., 0., 0.]
     while True:

--- a/utils/medialoader.py
+++ b/utils/medialoader.py
@@ -46,12 +46,18 @@ class MediaLoader(object):
         self.thread = Thread(target=self.update, args=([cap, source, wait_ms]), daemon=True)
         print(f"-- Success ({self.frame} frames {self.w}x{self.h} at {self.fps:.2f} FPS)")
         self.alive = True
-        self.thread.start()
+        self.bpause = False
 
+    def start(self):
+        self.bpause = False
+        self.thread.start()
 
     def update(self, cap, stream, wait_ms=0.01):
         n, f = 0, self.frame
         while cap.isOpened() and n < f and self.alive:
+            if self.bpause is True:
+                time.sleep(0.01)
+                continue
             n += 1
             cap.grab()
             if n % self.stride == 0:
@@ -73,15 +79,25 @@ class MediaLoader(object):
         orig_im = self.img.copy()
         return orig_im
 
-    def show_frame(self, wait_sec:int=0):
+    def show_frame(self, wait_sec: int = 0):
         frame = self.get_frame()
         cv2.imshow("frame", frame)
         if cv2.waitKey(wait_sec) == ord('q'):
+            print("-- Quit Show frames")
             raise StopIteration
 
     def stop(self):
         self.alive = False
         self.thread.join(timeout=1)
+
+    def pause(self):
+        self.bpause = True
+
+    def is_pause(self):
+        return self.bpause
+
+    def restart(self):
+        self.bpause = False
 
     def __del__(self):
         self.cap.release()
@@ -94,8 +110,21 @@ if __name__ == "__main__":
     s = sys.argv[1]      # video file, webcam, rtsp stream.. etc
 
     medialoader = MediaLoader(s)
-    time.sleep(1)
+    medialoader.start()
+    while medialoader.is_frame_ready() is False:
+        time.sleep(0.01)
+        continue
+    print("-- MediaLoader is ready")
     _frame = medialoader.get_frame()
-    print(_frame.shape, _frame.dtype)
+    print("-- Frame Metadata:", _frame.shape, _frame.dtype)
+    t = time.time()
     while True:
-        medialoader.show_frame(wait_sec=1)
+        cur_t = time.time()
+        if 5 < cur_t - t < 10:
+            medialoader.pause()
+        else:
+            if medialoader.is_pause() is True:
+                medialoader.restart()
+            else:
+                medialoader.show_frame(wait_sec=1)
+        time.sleep(0.005)


### PR DESCRIPTION
- media loader 의 start 메소드 분리 및 일시정지 기능 생성
  - start를 하지 않으면 특정 소스의 미디어 로더를 만들어도 update 쓰레드가 돌지 않는다.
  - 일시정지(pause)를 걸면 다시 프레임을 읽기위해서 restart가 필요하다